### PR TITLE
Update mem output format and extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+install_manifest.txt
+screen-cpu-usage

--- a/screen-mem-usage
+++ b/screen-mem-usage
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-total_mem=$(/usr/bin/free -m | /usr/bin/awk '$1 == "Mem:" { print $2 }')
+total_mem=$(/usr/bin/free -tm | /usr/bin/awk '$1 == "Mem:" { print $2 }')
 
 while(true); do
-  current_mem=$(/usr/bin/free -m | /usr/bin/awk '$1 == "-/+" { print $3 }')
+  current_mem=$(/usr/bin/free -tm | /usr/bin/awk '$1 == "Mem:" { print $3 }')
   echo "${current_mem}MB/${total_mem}MB"
   sleep 3
 done


### PR DESCRIPTION
The output format has changed and mem was unable to find the current usage and
totals.  This small tweak helps that.  The gitignore addition just covers items
generated as part of the cmake process.

